### PR TITLE
Add tail_log script

### DIFF
--- a/administration/tail_log.sh
+++ b/administration/tail_log.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "Running as $(whoami)"
+
+echo "Find PostgreSQL data directory"
+pgdata="$(psql $DATABASE_URL -c 'SHOW data_directory' --tuples-only | sed 's/^[ \t]*//')"
+
+echo "Find current log file"
+pglog="$(psql -U postgres -c 'SELECT pg_current_logfile()' --tuples-only | awk '{print $1}')"
+
+full_path="$pgdata/$pglog"
+echo "full_path: $full_path"
+
+tail -f "$full_path"


### PR DESCRIPTION
Dynamically find the data directory and current log file, and assemble a
new full path to then call from "tail"

Usage:

```sh
andy@Andrews-Laptop ~/P/p/administration (chore/add-tail-logs)> sh tail_log.sh
Running as andy
Find PostgreSQL data directory
Find current log file
full_path: /Users/andy/Library/Application Support/Postgres/var-16/log/postgresql-2023-12-11_155710.log
pid=66921 query_id=0: LOG:  checkpoint complete: wrote 7 buffers (0.0%); 0 WAL file(s) added, 0 removed, 0 recycled; write=0.623 s, sync=0.001 s, total=0.639 s; sync files=5, longest=0.001 s, average=0.001 s; distance=25 kB, estimate=57 kB; lsn=1F/1ADC47F8, redo lsn=1F/1ADC47C0
pid=66926 query_id=5049977816531726673: LOG:  cron job 4 starting: VACUUM (ANALYZE) rideshare.trips
...
```