### PR TITLE
Add UUID examples. Page density exploration.

### DIFF
--- a/uuid_experiments/README.md
+++ b/uuid_experiments/README.md
@@ -1,27 +1,29 @@
 # UUID Experiments
 
-- UUID v7 extension
+## PgPrewarm and Pageinspect
+```sql
+create extension if not exists pg_prewarm;
+create extension if not exists pageinspect;
+```
+
+- Use UUID v7 extension to generate values on Postgres 16
 <https://pgxn.org/dist/pg_uuidv7/>
-- enable `pg_prewarm`
-- enable `pageinspect`
+- enable `pageinspect` in target DB
+
+I run Postgres 16 on macOS using [Postgres.app](https://postgresapp.com).
 
 ```sh
 cd # into pg_uuidv7 directory
-```
-
-Needs libpq, make sure it's using Postgres.app version.
-
-```sh
 make
 sudo make install PG_CONFIG=/Applications/Postgres.app/Contents/Versions/16/bin/pg_config
+```
+
+Then from psql, in the target database:
+```sql
 create extension pg_uuidv7;
 ```
 
 - Reproduce results here:
 <https://www.cybertec-postgresql.com/en/unexpected-downsides-of-uuid-keys-in-postgresql/>
 
-## Pageinspect
-```sql
-create extension if not exists pageinspect;
-```
-
+For the page density comparison, see page_density.sql

--- a/uuid_experiments/README.md
+++ b/uuid_experiments/README.md
@@ -1,0 +1,27 @@
+# UUID Experiments
+
+- UUID v7 extension
+<https://pgxn.org/dist/pg_uuidv7/>
+- enable `pg_prewarm`
+- enable `pageinspect`
+
+```sh
+cd # into pg_uuidv7 directory
+```
+
+Needs libpq, make sure it's using Postgres.app version.
+
+```sh
+make
+sudo make install PG_CONFIG=/Applications/Postgres.app/Contents/Versions/16/bin/pg_config
+create extension pg_uuidv7;
+```
+
+- Reproduce results here:
+<https://www.cybertec-postgresql.com/en/unexpected-downsides-of-uuid-keys-in-postgresql/>
+
+## Pageinspect
+```sql
+create extension if not exists pageinspect;
+```
+

--- a/uuid_experiments/create_indexes.sql
+++ b/uuid_experiments/create_indexes.sql
@@ -1,0 +1,18 @@
+\timing on
+
+create index on records (id);      -- records_id_idx
+create index on records (uuid_v4); -- records_uuid_v4_idx
+create index on records (uuid_v7); -- records_uuid_v7_idx
+vacuum analyze records;
+
+SELECT
+    relname,
+    pg_size_pretty(pg_relation_size(oid)),
+    pg_prewarm (oid)
+FROM
+    pg_class
+WHERE
+    relname LIKE 'records%';
+
+EXPLAIN (BUFFERS, ANALYZE, TIMING OFF) SELECT COUNT(id) FROM records;
+EXPLAIN (BUFFERS, ANALYZE, TIMING OFF) SELECT COUNT(uuid_v4) FROM records;

--- a/uuid_experiments/create_tables.sql
+++ b/uuid_experiments/create_tables.sql
@@ -1,0 +1,31 @@
+CREATE TABLE records (
+    id int8 NOT NULL,
+    uuid_v4 uuid NOT NULL,
+    uuid_v7 uuid NOT NULL,
+    filler text
+);
+
+-- 10 million inserts
+INSERT INTO records
+SELECT
+    id,
+    gen_random_uuid(),
+    uuid_generate_v7(),
+    repeat(' ', 100)
+FROM
+    generate_series(1, 10000000) id;
+
+-- 1 million updates
+CREATE TEMP TABLE update_ids AS
+SELECT id
+FROM generate_series(1, 10000000) id
+ORDER BY random()
+LIMIT 1000000;
+
+-- Perform the updates on uuid_v4 and uuid_v7 columns (and filler text)
+UPDATE records
+SET
+  uuid_v4 = gen_random_uuid(),
+  uuid_v7 = uuid_generate_v7(),
+  filler = repeat('x', 100)
+WHERE id IN (SELECT id FROM update_ids);

--- a/uuid_experiments/page_density.sql
+++ b/uuid_experiments/page_density.sql
@@ -1,0 +1,59 @@
+create extension if not exists pageinspect;
+
+-- bt_page_stats returns summary information about a data page of a B-tree index. For example:
+-- https://www.postgresql.org/docs/17/pageinspect.html
+
+-- average leaf density
+WITH index_info AS (
+  SELECT 'records_id_idx'::text AS idxname
+  UNION ALL
+  SELECT 'records_uuid_v4_idx'::text
+  UNION ALL
+  SELECT 'records_uuid_v7_idx'::text
+),
+page_counts AS (
+  SELECT
+    idxname,
+    pg_relation_size(idxname) / 8192 AS num_pages  -- number of 8KB pages
+  FROM index_info
+),
+all_pages AS (
+  SELECT
+    idxname,
+    generate_series(1, num_pages - 1) AS blkno
+  FROM page_counts
+),
+page_stats AS (
+  SELECT
+    idxname,
+    (bt_page_stats(idxname, blkno)).*
+  FROM all_pages
+),
+leaf_pages AS (
+  SELECT
+    idxname,
+    100 - (free_size::float / 8192 * 100) AS fill_percent
+  FROM page_stats
+  WHERE type = 'l'
+)
+SELECT
+  idxname,
+  ROUND(AVG(fill_percent)::numeric, 2) AS avg_leaf_fill_percent
+FROM leaf_pages
+GROUP BY idxname;
+
+-- After updates
+--  idxname       | avg_leaf_fill_percent
+-- ---------------------+-----------------------
+--  records_id_idx      |                 97.64
+--  records_uuid_v4_idx |                 79.06
+--  records_uuid_v7_idx |                 90.09
+-- (3 rows)
+--
+-- v4
+-- ⚠️ Implication:
+--
+-- Write amplification is high
+-- Index bloat will grow steadily over time
+-- You will eventually need a REINDEX or pg_repack to reclaim wasted space
+-- Poorer cache locality and lookup performance may follow


### PR DESCRIPTION
# Blog post
[Avoid UUID Version 4 Primary Keys](https://andyatkinson.com/constraint-driven-optimized-responsive-efficient-core-db-design)

# UUID Experiments

## PgPrewarm and Pageinspect
```sql
create extension if not exists pg_prewarm;
create extension if not exists pageinspect;
```

- Use UUID v7 extension to generate values on Postgres 16
<https://pgxn.org/dist/pg_uuidv7/>
- enable `pageinspect` in target DB

I run Postgres 16 on macOS using [Postgres.app](https://postgresapp.com).

```sh
cd # into pg_uuidv7 directory
make
sudo make install PG_CONFIG=/Applications/Postgres.app/Contents/Versions/16/bin/pg_config
```

Then from psql, in the target database:
```sql
create extension pg_uuidv7;
```

- Reproduce results here:
<https://www.cybertec-postgresql.com/en/unexpected-downsides-of-uuid-keys-in-postgresql/>

For the page density comparison, see page_density.sql